### PR TITLE
add comment about App.css

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,1 +1,2 @@
 /* Add your plugin styles here. */
+/* Refused to apply style from 'http://localhost:8080/App.css' because its MIME type ('text/html') is not a supported stylesheet MIME type, and strict MIME checking is enabled. */


### PR DESCRIPTION
### Summary 🎯

Bug in official app when I inspect element and check the console
GET https://www.remnoteplugins.com/incremental-everything/0.0.19/App.css net::ERR_ABORTED 403 (Forbidden)

Bug in my test app when I inspect element and check the console
Refused to apply style from 'http://localhost:8080/App.css' because its MIME type ('text/html') is not a supported stylesheet MIME type, and strict MIME checking is enabled.

### Changes 🔁

-
